### PR TITLE
Merge script alias support

### DIFF
--- a/src/net/coagulate/GPHUD/Data/Script.java
+++ b/src/net/coagulate/GPHUD/Data/Script.java
@@ -300,4 +300,12 @@ public class Script extends TableRow {
     public int getCompilerVersion() {
 		return getInt("compilerversion");
     }
+
+	public @Nonnull String alias() {
+		String alias=getStringNullable("alias");
+		return alias==null?"":alias;
+	}
+	public void alias(@Nullable String newAlias) {
+		set("alias",newAlias);
+	}
 }

--- a/src/net/coagulate/GPHUD/Data/Script.java
+++ b/src/net/coagulate/GPHUD/Data/Script.java
@@ -40,9 +40,9 @@ public class Script extends TableRow {
 	@Nonnull
 	public static Table getTable(@Nonnull final State state,final boolean canDelete) {
 		@Nonnull final Instance instance=state.getInstance();
-		final Results rows=db().dq("select id,name,sourceversion,bytecodeversion from scripts where instanceid=? order by name asc",instance.getId());
+		final Results rows=db().dq("select id,name,sourceversion,bytecodeversion,alias from scripts where instanceid=? order by name asc",instance.getId());
 		final Table o=new Table();
-		o.add(new HeaderRow().add("Name").add("Version").add("Compiled Version"));
+		o.add(new HeaderRow().add("Name").add("Version").add("Compiled Version").add("Alias"));
 		for (final ResultsRow row: rows) {
 			o.openRow();
 			o.add("<a href=\"/GPHUD/configuration/scripting/edit/"+row.getIntNullable("id")+"\">"+row.getStringNullable("name")+"</a>");
@@ -56,6 +56,9 @@ public class Script extends TableRow {
 				o.add("<font color=red>"+(sourceversion==null?"None":""+sourceversion)+"</font>");
 				o.add("<font color=red>"+(bytecodeversion==null?"None":""+bytecodeversion)+"</font>");
 			}
+			String alias=row.getStringNullable("alias");
+			if (alias==null) { alias=""; }
+			o.add(alias);
 			if (canDelete) {
 				o.add(new Form(state,true,"/GPHUD/configuration/scripting/delete","Delete","scriptname",row.getStringNullable("name")));
 			}

--- a/src/net/coagulate/GPHUD/GPHUD.java
+++ b/src/net/coagulate/GPHUD/GPHUD.java
@@ -320,9 +320,15 @@ public class GPHUD extends SLModule {
 			log.config("Schema upgrade of GPHUD to version 12 is complete");
 			currentVersion=12;
 		}
+		if (currentVersion==12) {
+			log.config("Add alias to scripts");
+			GPHUD.getDB().d("ALTER TABLE `scripts` ADD COLUMN `alias` VARCHAR(64) NULL DEFAULT NULL AFTER `parameterlist`");
+			log.config("Schema upgrade of GPHUD to version 13 is complete");
+			currentVersion=13;
+		}
 		return currentVersion;
 	}
-	private static final int SCHEMA_VERSION=12;
+	private static final int SCHEMA_VERSION=13;
 
 	@Override
 	public void startup() {

--- a/src/net/coagulate/GPHUD/Modules/Scripting/ScriptingConfig.java
+++ b/src/net/coagulate/GPHUD/Modules/Scripting/ScriptingConfig.java
@@ -89,6 +89,9 @@ public class ScriptingConfig {
 		final String id=split[split.length-1];
 		final Script script=Script.get(Integer.parseInt(id));
 		script.validate(st);
+		if (!values.get("scriptalias").isEmpty()) {
+			script.alias(values.get("scriptalias"));
+		}
 		if (!values.get("scriptsource").isEmpty()) {
 			script.setSource(values.get("scriptsource"));
 			f.p("Script source saved OK!");
@@ -143,6 +146,7 @@ public class ScriptingConfig {
 		else {
 			versions.add("Byte code version").add(script.getByteCodeVersion()+"");
 		}
+		versions.openRow().add("Script alias").add(new TextInput("scriptalias",script.alias()));
 		f.add(versions);
 		f.br();
 		f.add("<textarea name=scriptsource rows=25 cols=80>"+script.getSource()+"</textarea>");


### PR DESCRIPTION
ADD: Added support for an alternative name (alias) for a script, which can be used as an alternative reference in e.g. scripting calls, useful should the script have an unusable name in scripting.