### PR TITLE
Suppress error reporting of Quick Buttons invoking Quick Buttons being not permitted.

### DIFF
--- a/src/net/coagulate/GPHUD/Modules/GPHUDClient/QuickButtons.java
+++ b/src/net/coagulate/GPHUD/Modules/GPHUDClient/QuickButtons.java
@@ -84,7 +84,7 @@ public class QuickButtons {
 		}
 		if (commandname.toLowerCase().startsWith("gphudclient.quickbutton")) {
 			throw new UserConfigurationException(
-					"Quick button "+button+" is not permitted to call another quick button ("+commandname+")");
+					"Quick button "+button+" is not permitted to call another quick button ("+commandname+")",true);
 		}
 		return templateOrRun(st,commandname);
 	}


### PR DESCRIPTION
Because apparently people do this, perhaps even making a button call its self, and as crazy as that is, and this error is thrown to defend against the obvious infinite loop problems, I personally don't care to be notified about this problem.  It's a you problem, not a me problem.