### PR TITLE
Fixes split cache issue where objects would be dual manifest for 24 hours on creation

### DIFF
--- a/src/net/coagulate/GPHUD/Data/Obj.java
+++ b/src/net/coagulate/GPHUD/Data/Obj.java
@@ -241,7 +241,7 @@ public class Obj extends TableRow {
 		final Obj obj=objectUUIDCache.get(uuid,()->{
 			final Integer id=db().dqi("select id from objects where uuid=?",uuid);
 			if (id==null) { return null; }
-			return new Obj(id);
+			return Obj.get(id);
 		});
 		if (obj==null) { throw new UserInputLookupFailureException("Object "+uuid+" is not registered"); }
 		return obj;

--- a/src/net/coagulate/GPHUD/Data/Obj.java
+++ b/src/net/coagulate/GPHUD/Data/Obj.java
@@ -71,7 +71,10 @@ public class Obj extends TableRow {
 				} else {
 					final Integer oldobjecttype=row.getIntNullable("objecttype");
 					if (oldobjecttype==null||oldobjecttype!=Integer.parseInt(objecttype)) {
-						db().d("update objects set objecttype=? where id=?",objecttype,row.getIntNullable("id"));
+						final Obj obj=Obj.get(row.getInt("id"));
+						final ObjType otraw=ObjType.get(Integer.parseInt(objecttype));
+						final ObjectType ot=ObjectType.materialise(st,otraw);
+						obj.setObjectType(otraw);
 						Audit.audit(st,
 						            Audit.OPERATOR.AVATAR,
 						            null,
@@ -82,8 +85,6 @@ public class Obj extends TableRow {
 						            objecttype,
 						            "Set object type for "+row.getStringNullable("name")+" "+
 						            row.getStringNullable("uuid"));
-						final Obj obj=Obj.get(row.getInt("id"));
-						final ObjectType ot=ObjectType.materialise(st,ObjType.get(Integer.parseInt(objecttype)));
 						final JSONObject reconfigurepayload=new JSONObject();
 						ot.payload(st,reconfigurepayload,obj.getRegion(),obj.getURL());
 						new Transmission(Obj.get(row.getInt("id")),reconfigurepayload).start();


### PR DESCRIPTION
Ultimately there were two entries in the cache, one formed by object UUID lookup (such as when the object connects), and another formed by getting the object by DB row ID (used during the HTML interface), it was possible for the latter to generate a distinct object and corrupt the cache for 24 hours (expiration time) desynchronising the objects behaviour and the web UI's behaviour, though messages could be pushed from the web side by flipping the objects behaviour.

Ultimately the get-by-row-id method should never have been generating new objects, that is exclusively the job of the factory, and by properly utilising the factory to locate existing objects by row ID the second conflicting object is never formed and both UUID and rowID resolution produce the same result, as expected and required.

Sunday fun :)