### PR TITLE
Scripts can offer websites

### DIFF
--- a/src/net/coagulate/GPHUD/Modules/GPHUDClient/OpenWebsite.java
+++ b/src/net/coagulate/GPHUD/Modules/GPHUDClient/OpenWebsite.java
@@ -45,7 +45,6 @@ public class OpenWebsite {
 	          permitUserWeb=false,
 	          permitObject=false,
 	          permitExternal=false,
-	          permitConsole=false,
 	          permitScripting=false)
 	public static Response offerWebsite(@Nonnull final State st,
 	                                    @Argument.Arguments(name="url",

--- a/src/net/coagulate/GPHUD/Modules/GPHUDClient/OpenWebsite.java
+++ b/src/net/coagulate/GPHUD/Modules/GPHUDClient/OpenWebsite.java
@@ -44,7 +44,9 @@ public class OpenWebsite {
 	          description="Causes the GPHUD to send an llOpenURL to the user with a custom URL/description",
 	          permitUserWeb=false,
 	          permitObject=false,
-	          permitExternal=false)
+	          permitExternal=false,
+	          permitConsole=false,
+	          permitScripting=false)
 	public static Response offerWebsite(@Nonnull final State st,
 	                                    @Argument.Arguments(name="url",
 	                                                        description="URL to offer to user",

--- a/src/net/coagulate/GPHUD/Modules/GPHUDClient/package-info.java
+++ b/src/net/coagulate/GPHUD/Modules/GPHUDClient/package-info.java
@@ -300,6 +300,17 @@
         type=CHANGETYPE.Fix,
         component=COMPONENT.HUD,
         message="Resolved a race condition on reboot calls to the HUD, e.g. GPHUDClient.Reboot, where the HUD would reconnect instantly and may end up logging its self out.  HUD now waits for logout to complete before reconnecting.  <b>Requires region server update.</b>")
+
+@Change(date="2024-10-06",
+        type=CHANGETYPE.Delete,
+        component=COMPONENT.API,
+        message="Removed console and scripting access to GPHUDClient.offerWebsite - this command only ever works if the user directly calls this from the HUD")
+
+@Change(date="2024-10-06",
+        type=CHANGETYPE.Add,
+        component=COMPONENT.Scripting,
+        message="Added gsOfferWebsite which properly formate a GPHUDClient.offerWebsite response and forwards it to the player's HUD")
+		
 package net.coagulate.GPHUD.Modules.GPHUDClient;
 
 import net.coagulate.GPHUD.Classes.COMPONENT;

--- a/src/net/coagulate/GPHUD/Modules/Scripting/Language/Functions/Output.java
+++ b/src/net/coagulate/GPHUD/Modules/Scripting/Language/Functions/Output.java
@@ -3,7 +3,9 @@ package net.coagulate.GPHUD.Modules.Scripting.Language.Functions;
 import net.coagulate.Core.Exceptions.System.SystemConsistencyException;
 import net.coagulate.GPHUD.Data.Landmark;
 import net.coagulate.GPHUD.Data.Obj;
+import net.coagulate.GPHUD.Interfaces.Responses.Response;
 import net.coagulate.GPHUD.Interfaces.System.Transmission;
+import net.coagulate.GPHUD.Modules.GPHUDClient.OpenWebsite;
 import net.coagulate.GPHUD.Modules.Scripting.Language.ByteCode.BCCharacter;
 import net.coagulate.GPHUD.Modules.Scripting.Language.ByteCode.BCInteger;
 import net.coagulate.GPHUD.Modules.Scripting.Language.ByteCode.BCString;
@@ -204,6 +206,26 @@ public class Output {
 		send.put("linkmessage",message.toString());
 		send.put("linkid",id.toString());
 		new Transmission(object,send).start();
+		return new BCInteger(null,0);
+	}
+	
+	@Nonnull
+	@GSFunctions.GSFunction(description="Offer a website to a specific character",
+	                        parameters="Character - Character to offer to<br>String - URL to offer, must be http:// or https://<br>String - Description to show for the URL",
+	                        notes="",
+	                        returns="Integer - One if the character is offline, zero otherwise",
+	                        privileged=false,
+	                        category=SCRIPT_CATEGORY.OUTPUT)
+	public static BCInteger gsOfferWebsite(final State st,
+	                                       @Nonnull final GSVM vm,
+	                                       @Nonnull final BCCharacter target,
+	                                       @Nonnull final BCString URL,
+	                                       @Nonnull final BCString description) {
+		if (!target.isOnline()) { return new BCInteger(null,1); }
+		final State bypass=new State(st.getInstanceNullable(),st.getRegionNullable(),st.zone,st.getCharacterNullable());
+		bypass.source=State.Sources.SYSTEM;
+		final Response response=OpenWebsite.offerWebsite(bypass,URL.getContent(),description.getContent());
+		target.getContent().push(response.asJSON(st));
 		return new BCInteger(null,0);
 	}
 }


### PR DESCRIPTION
Prevents scripts from calling GPHUDClient.offerWebsite which does not work through gsAPI's invocation (and is returned to the script to be distilled into a text or integer result).  Adds gsOfferWebsite which replicates the functionality and uses HUD push as the delivery path rather than API response.