### PR TITLE
Fix for Issue #60 - Applied effects icon not appearing in the HUD

### DIFF
--- a/src/net/coagulate/GPHUD/Data/Effect.java
+++ b/src/net/coagulate/GPHUD/Data/Effect.java
@@ -383,6 +383,7 @@ public class Effect extends TableRow {
 		}
 		d("delete from effectsapplications where effectid=? and characterid=?",getId(),target.getId());
 		d("insert into effectsapplications(effectid,characterid,expires) values(?,?,?)",getId(),target.getId(),expires);
+		effectCache.purge(target);
 		Audit.OPERATOR operator=Audit.OPERATOR.CHARACTER;
 		if (administrative) {
 			operator=Audit.OPERATOR.AVATAR;


### PR DESCRIPTION
Effect cache doesn't get a chance to invalidate itself in time.   This will invalidate the cache on applying an effect to avoid potential race conditions and allow HUD to receive timely updates.