### PR TITLE
BugFix: RunCommand dropdown and prevent premature update

### DIFF
--- a/src/net/coagulate/GPHUD/Modules/Objects/ObjectManagement.java
+++ b/src/net/coagulate/GPHUD/Modules/Objects/ObjectManagement.java
@@ -123,7 +123,9 @@ public class ObjectManagement {
 		final Form f=st.form();
 		f.add(new TextHeader("Object Type: "+t.getName()));
 		final ObjectType ot=ObjectType.materialise(st,t);
-		ot.update(st);
+		if (!st.postMap().isEmpty()) {
+			ot.update(st);
+		}
 		f.add(ot.explainHtml());
 		ot.editForm(st);
 	}

--- a/src/net/coagulate/GPHUD/Modules/Objects/ObjectTypes/RunCommand.java
+++ b/src/net/coagulate/GPHUD/Modules/Objects/ObjectTypes/RunCommand.java
@@ -33,7 +33,9 @@ public class RunCommand extends ObjectType {
 	@Override
 	public void editForm(@Nonnull final State st) {
 		final Table t=new Table();
-		t.add("Command").add(DropDownList.getCommandsList(st,"command",true));
+		final DropDownList commands=DropDownList.getCommandsList(st,"command",true);
+		commands.setValue(json.optString("command",""));
+		t.add("Command").add(commands);
 		t.openRow();
 		editFormDistance(st,t);
 		t.add(new Cell(new Button("Submit"),2));


### PR DESCRIPTION
User-facing BugFix: RunCommand dropdown and prevent premature update

The dropdown for the 'command' in the RunCommand object type configuration was not being pre-populated with saved data, this caused the value to be cleared unintentionally when a user navigated to the Object configuration page and viewed a RunCommand object.

This commit resolves two related issues that caused the configuration for the RunCommand object type to be cleared unintentionally.

1.  In ObjectManagement the editObjectType method was unconditionally calling the update method on the object type.  In the case of the RunCommand objext this caused the data to be cleared on the initial page load before the form was even displayed. The fix now calls the update method if the request contains POST data

2.  In RunCommand the editForm method was not preselecting the currently configured command in the dropdown list. Now it will set the dropdown's value from the stored config