### PR TITLE
"Duplicate entry" error on rare occasions, which means th…

### DIFF
--- a/src/net/coagulate/GPHUD/Data/Effect.java
+++ b/src/net/coagulate/GPHUD/Data/Effect.java
@@ -382,8 +382,7 @@ public class Effect extends TableRow {
 			// already has a same or longer lasting effect
 			return false;
 		}
-		d("delete from effectsapplications where effectid=? and characterid=?",getId(),target.getId());
-		d("insert into effectsapplications(effectid,characterid,expires) values(?,?,?)",getId(),target.getId(),expires);
+        d("replace into effectsapplications(effectid,characterid,expires) values(?,?,?)",getId(),target.getId(),expires);
 		effectCache.purge(target);
 		Audit.OPERATOR operator=Audit.OPERATOR.CHARACTER;
 		if (administrative) {


### PR DESCRIPTION
"Duplicate entry" error on rare occasions, which means the code is trying to insert a row into a table with a PK that already existed.

Traced the error to the apply method of the Effect class.

The problem lies in the fact that the DELETE and INSERT operations are not atomic. Creating a potential race condition where two concurrent requests can both pass the initial "effect alread on for longer" check, and then both attempt to insert the same record, leading to the dup key exception.

Replacing the separate DELETE and INSERT statements with an atomic REPLACE INTO solves.

(cherry picked from commit 584eec9029558b9a176a1468bee8ab3f2776fc95)