### PR TITLE
Fix titler stagnation.

### DIFF
--- a/src/net/coagulate/GPHUD/Data/Effect.java
+++ b/src/net/coagulate/GPHUD/Data/Effect.java
@@ -271,6 +271,7 @@ public class Effect extends TableRow {
 			            "Effect "+getName()+" expired from character");
 		}
 		d("delete from effectsapplications where characterid=? and effectid=?",character.getId(),getId());
+        effectCache.purge(character);
 		final String applykv=st.getKV(this,"Effects.RemoveMessage");
 		final JSONObject message=new JSONObject();
 		if (applykv!=null&&(!applykv.isEmpty())) {


### PR DESCRIPTION
Cache Miss bug but with a twist: When unapply for effect is called - Effect.get checks effectCache. Since unapply didn't purge it, the cache returns the old list of effects (including the one just deleted).  However, effect icons seem to "properly" update because conveyEffects iterates the stale list but calls remains() on each effect. remains() hits the database directly, sees the row is gone, returns proper. The system sends this "expired" timestamp to the HUD, so the icon correctly disappears - hiding the cache miss.

Which then brings us to... the Titler Stagnation; appendConveyance runs next to check if the Titler (or other KVs) changed. The Titler template calls Effect.get (via EffectsFunctions or similar), hits the same stale cache, and generates the same text string as before.